### PR TITLE
add buildomat build script

### DIFF
--- a/.github/buildomat/config.toml
+++ b/.github/buildomat/config.toml
@@ -1,0 +1,10 @@
+#
+# This file, with this flag, must be present in the default branch in order for
+# the buildomat integration to create check suites.
+#
+enable = true
+
+#
+# Require approval for pull requests made by users outside our organisation.
+#
+org_only = true

--- a/.github/buildomat/jobs/image.sh
+++ b/.github/buildomat/jobs/image.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+#:
+#: name = "image"
+#: variety = "basic"
+#: target = "helios-latest"
+#: output_rules = [
+#:   "/out/*",
+#: ]
+#:
+#: [[publish]]
+#: series = "image_release"
+#: name = "OVMF_CODE.tar.gz"
+#: from_output = "/out/release/OVMF_CODE.tar.gz"
+#:
+#: [[publish]]
+#: series = "image_release"
+#: name = "OVMF_CODE.tar.gz.sha256.txt"
+#: from_output = "/out/release/OVMF_CODE.tar.gz.sha256.txt"
+#:
+#: [[publish]]
+#: series = "image_debug"
+#: name = "OVMF_CODE.tar.gz"
+#: from_output = "/out/debug/OVMF_CODE.tar.gz"
+#:
+#: [[publish]]
+#: series = "image_debug"
+#: name = "OVMF_CODE.tar.gz.sha256.txt"
+#: from_output = "/out/debug/OVMF_CODE.tar.gz.sha256.txt"
+
+set -o errexit
+set -o pipefail
+set -o xtrace
+
+release_dir="/out/release"
+debug_dir="/out/debug"
+
+# The build relies on submodules that aren't initially part of a fresh clone.
+banner checkout
+git submodule init
+git submodule update
+
+banner build
+chmod +x illumos/build.sh
+illumos/build.sh DEBUG
+illumos/build.sh RELEASE
+
+banner contents
+tar -czvf Build/OvmfX64/RELEASE_ILLGCC/FV/OVMF_CODE.tar.gz \
+    -C Build/OvmfX64/RELEASE_ILLGCC/FV OVMF_CODE.fd
+
+tar -czvf Build/OvmfX64/DEBUG_ILLGCC/FV/OVMF_CODE.tar.gz \
+    -C Build/OvmfX64/DEBUG_ILLGCC/FV OVMF_CODE.fd
+
+banner copy
+pfexec mkdir -p $release_dir
+pfexec mkdir -p $debug_dir
+pfexec chown "$UID" $release_dir
+pfexec chown "$UID" $debug_dir
+mv Build/OvmfX64/RELEASE_ILLGCC/FV/OVMF_CODE.tar.gz \
+    $release_dir/OVMF_CODE.tar.gz
+mv Build/OvmfX64/DEBUG_ILLGCC/FV/OVMF_CODE.tar.gz \
+    $debug_dir/OVMF_CODE.tar.gz
+cd $release_dir
+digest -a sha256 OVMF_CODE.tar.gz > OVMF_CODE.tar.gz.sha256.txt
+cd $debug_dir
+digest -a sha256 OVMF_CODE.tar.gz > OVMF_CODE.tar.gz.sha256.txt

--- a/.github/buildomat/jobs/image.sh
+++ b/.github/buildomat/jobs/image.sh
@@ -4,28 +4,31 @@
 #: variety = "basic"
 #: target = "helios-latest"
 #: output_rules = [
-#:   "/out/*",
+#:   "=/out/release/OVMF_CODE.fd",
+#:   "=/out/release/OVMF_CODE.fd.sha256.txt",
+#:   "=/out/debug/OVMF_CODE.fd",
+#:   "=/out/debug/OVMF_CODE.sha256.txt",
 #: ]
 #:
 #: [[publish]]
 #: series = "image_release"
-#: name = "OVMF_CODE.tar.gz"
-#: from_output = "/out/release/OVMF_CODE.tar.gz"
+#: name = "OVMF_CODE.fd"
+#: from_output = "/out/release/OVMF_CODE.fd"
 #:
 #: [[publish]]
 #: series = "image_release"
-#: name = "OVMF_CODE.tar.gz.sha256.txt"
-#: from_output = "/out/release/OVMF_CODE.tar.gz.sha256.txt"
+#: name = "OVMF_CODE.fd.sha256.txt"
+#: from_output = "/out/release/OVMF_CODE.fd.sha256.txt"
 #:
 #: [[publish]]
 #: series = "image_debug"
-#: name = "OVMF_CODE.tar.gz"
-#: from_output = "/out/debug/OVMF_CODE.tar.gz"
+#: name = "OVMF_CODE.fd"
+#: from_output = "/out/debug/OVMF_CODE.fd"
 #:
 #: [[publish]]
 #: series = "image_debug"
-#: name = "OVMF_CODE.tar.gz.sha256.txt"
-#: from_output = "/out/debug/OVMF_CODE.tar.gz.sha256.txt"
+#: name = "OVMF_CODE.fd.sha256.txt"
+#: from_output = "/out/debug/OVMF_CODE.fd.sha256.txt"
 
 set -o errexit
 set -o pipefail
@@ -44,23 +47,16 @@ chmod +x illumos/build.sh
 illumos/build.sh DEBUG
 illumos/build.sh RELEASE
 
-banner contents
-tar -czvf Build/OvmfX64/RELEASE_ILLGCC/FV/OVMF_CODE.tar.gz \
-    -C Build/OvmfX64/RELEASE_ILLGCC/FV OVMF_CODE.fd
-
-tar -czvf Build/OvmfX64/DEBUG_ILLGCC/FV/OVMF_CODE.tar.gz \
-    -C Build/OvmfX64/DEBUG_ILLGCC/FV OVMF_CODE.fd
-
 banner copy
 pfexec mkdir -p $release_dir
 pfexec mkdir -p $debug_dir
 pfexec chown "$UID" $release_dir
 pfexec chown "$UID" $debug_dir
-mv Build/OvmfX64/RELEASE_ILLGCC/FV/OVMF_CODE.tar.gz \
-    $release_dir/OVMF_CODE.tar.gz
-mv Build/OvmfX64/DEBUG_ILLGCC/FV/OVMF_CODE.tar.gz \
-    $debug_dir/OVMF_CODE.tar.gz
+mv Build/OvmfX64/RELEASE_ILLGCC/FV/OVMF_CODE.fd \
+    $release_dir/OVMF_CODE.fd
+mv Build/OvmfX64/DEBUG_ILLGCC/FV/OVMF_CODE.fd \
+    $debug_dir/OVMF_CODE.fd
 cd $release_dir
-digest -a sha256 OVMF_CODE.tar.gz > OVMF_CODE.tar.gz.sha256.txt
+digest -a sha256 OVMF_CODE.fd > OVMF_CODE.fd.sha256.txt
 cd $debug_dir
-digest -a sha256 OVMF_CODE.tar.gz > OVMF_CODE.tar.gz.sha256.txt
+digest -a sha256 OVMF_CODE.fd > OVMF_CODE.fd.sha256.txt

--- a/.github/buildomat/jobs/image.sh
+++ b/.github/buildomat/jobs/image.sh
@@ -7,7 +7,7 @@
 #:   "=/out/release/OVMF_CODE.fd",
 #:   "=/out/release/OVMF_CODE.fd.sha256.txt",
 #:   "=/out/debug/OVMF_CODE.fd",
-#:   "=/out/debug/OVMF_CODE.sha256.txt",
+#:   "=/out/debug/OVMF_CODE.fd.sha256.txt",
 #: ]
 #:
 #: [[publish]]


### PR DESCRIPTION
Create a buildomat config file for our fork and an initial attempt at a script to build firmware images and publish them. This is needed for https://github.com/oxidecomputer/propolis/issues/362.

I think the script is mostly right, but we'll see! Buildomat won't actually run it until this PR is merged, since the repo's buildomat config is taken from HEAD of the default branch, and that won't exist until this merges.